### PR TITLE
'rId' shouldn't be removed from the r:id as other methods rely on the complete rId

### DIFF
--- a/lib/Data/XLSX/Parser/Workbook.pm
+++ b/lib/Data/XLSX/Parser/Workbook.pm
@@ -40,8 +40,7 @@ sub sheet_id {
         or return;
 
     if ($meta->{'r:id'}) {
-        (my $r = $meta->{'r:id'}) =~ s/^rId//;
-        return $r;
+        return $meta->{'r:id'};
     }
     else {
         return $meta->{sheetId};

--- a/t/1_____loreyna126.t
+++ b/t/1_____loreyna126.t
@@ -25,7 +25,7 @@ $parser->add_row_event_handler(sub {
     push @$cells, $row;
 });
 
-$parser->sheet(1);
+$parser->sheet_by_rid( $parser->workbook->sheet_id( $sheets[0] ) );
 
 is $cells->[112][0], 'RCS Thrust Vector Uncertainties ', 'val ok';
 

--- a/t/2_____with_chart.t
+++ b/t/2_____with_chart.t
@@ -25,7 +25,7 @@ $parser->add_row_event_handler(sub {
     push @$cells, $row;
 });
 
-$parser->sheet($parser->workbook->sheet_id($sheets[0]));
+$parser->sheet_by_rid($parser->workbook->sheet_id($sheets[0]));
 
 is $cells->[0][0], 1, 'val 0,0 ok';
 is $cells->[0][1], 10, 'val 0,1 ok';

--- a/t/bug-trim-space.t
+++ b/t/bug-trim-space.t
@@ -29,7 +29,9 @@ $parser->add_row_event_handler(sub {
     is $row->[ $col{C} ], 'c', 'c ok';
 });
 
-$parser->sheet(1);
+my $name = ( $parser->workbook->names )[0];
+my $rid  = $parser->workbook->sheet_id( $name );
+$parser->sheet_by_rid( $rid );
 
 ok $i, 'callback running ok';
 

--- a/t/format_test_sheet.t
+++ b/t/format_test_sheet.t
@@ -25,7 +25,8 @@ $parser->add_row_event_handler(sub {
     push @$cells, $row;
 });
 
-$parser->sheet(1);
+my $rid = $parser->workbook->sheet_id( $sheets[0] );
+$parser->sheet_by_rid($rid);
 
 is $cells->[1][1], 1;
 is $cells->[2][1], -3;


### PR DESCRIPTION
and change the tests to use sheet_by_rid instead of the deprecated method sheet